### PR TITLE
39 refactor database

### DIFF
--- a/src/Chirp.CLI/Program.cs
+++ b/src/Chirp.CLI/Program.cs
@@ -7,21 +7,19 @@ const string usage = @"Chirp.
 Usage:
   chirp.exe cheep <message>
   chirp.exe read
- 
 
 Options:
   -h --help     Show this screen.
   --version     Show version.
-
 ";
 
 var arguments = new Docopt().Apply(usage, args, version: "Chirp 0.1", exit: true)!;
 
+CSVDatabase<Cheep>.Init("../../data/chirp_cli_db.csv");
 IDatabaseRepository<Cheep> databaseRepository = CSVDatabase<Cheep>.Instance;
 
 if (arguments["read"].IsTrue)
 {
-
     // Read cheeps
     Userinterface.PrintCheeps(databaseRepository.Read());
 }
@@ -29,14 +27,14 @@ if (arguments["read"].IsTrue)
 // Post a cheep
 if (arguments["cheep"].IsTrue)
 {
-
     // Check for enough command line arguments
     if (arguments["<message>"].IsNullOrEmpty || arguments["<message>"].ToString() == "")
     {
-        throw new Exception("What is your message?");
+        throw new ArgumentException("No <message> was given");
     }
-
-    var cheep = Userinterface.CreateCheep(arguments["<message>"].ToString());
+    
+    var message = arguments["<message>"].ToString();
+    var cheep = new Cheep(Environment.UserName, message, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
     databaseRepository.Store(cheep);
     //store the data

--- a/src/Chirp.CLI/Userinterface.cs
+++ b/src/Chirp.CLI/Userinterface.cs
@@ -10,9 +10,4 @@ public static class Userinterface
             Console.WriteLine($"{cheep.Author} @ {cheep.Timestamp}: {cheep.Message}");
         });
     }
-    public static Cheep CreateCheep(string message)
-    {
-        var cheep = new Cheep(Environment.UserName, message, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
-        return cheep;
-    }
 }

--- a/src/SimpleDB/CSVDatabase.cs
+++ b/src/SimpleDB/CSVDatabase.cs
@@ -4,8 +4,13 @@ using System.Globalization;
 
 public sealed class CSVDatabase<T> : IDatabaseRepository<T>
 {
-    private static CSVDatabase<T>? instance = null;
-    private static readonly object padlock = new object();
+    private static CSVDatabase<T>? _instance;
+    private readonly string _path;
+
+    private CSVDatabase(string path)
+    {
+        _path = path;
+    }
 
     /*
     https://csharpindepth.com/articles/singleton
@@ -14,27 +19,33 @@ public sealed class CSVDatabase<T> : IDatabaseRepository<T>
     {
         get
         {
-            lock (padlock)
+            if (_instance == null)
             {
-                if (instance == null)
-                {
-                    instance = new CSVDatabase<T>();
-                }
-                return instance;
+                _instance = new CSVDatabase<T>("../../data/chirp_cli_db.csv");
             }
-
+            return _instance;
         }
     }
+
+    public static void Init(string path)
+    {
+        if (_instance == null)
+        {
+            _instance = new CSVDatabase<T>(path);
+        }
+    }
+    
     public IEnumerable<T> Read(int? limit = null)
     {
-        using var reader = new StreamReader("../chirp_cli_db.csv");
+        using var reader = new StreamReader(_path);
         using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
         var records = csv.GetRecords<T>().ToList();
         return records;
     }
+    
     public void Store(T record)
     {
-        using (var writer = new StreamWriter("../chirp_cli_db.csv", append: true))
+        using (var writer = new StreamWriter(_path, append: true))
         using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
         {
             csv.WriteRecord(record);

--- a/src/SimpleDB/CSVDatabase.cs
+++ b/src/SimpleDB/CSVDatabase.cs
@@ -35,7 +35,7 @@ public sealed class CSVDatabase<T> : IDatabaseRepository<T>
         }
     }
     
-    public IEnumerable<T> Read(int? limit = null)
+    public IEnumerable<T> Read(int limit)
     {
         using var reader = new StreamReader(_path);
         using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);

--- a/src/SimpleDB/IDatabaseRepository.cs
+++ b/src/SimpleDB/IDatabaseRepository.cs
@@ -2,6 +2,6 @@ namespace SimpleDB;
 
 public interface IDatabaseRepository<T>
 {
-    public IEnumerable<T> Read(int? limit = null);
+    public IEnumerable<T> Read(int limit = 0);
     public void Store(T record);
 }


### PR DESCRIPTION
- The csv file is located inside the SImpleDB project, instead of a parallel data directory
- The database should not be hardcoded with a specific csv file, but take its path as an argument
- Database constructor should be private, since it is a singleton
- Inconsistency with project description: Userinterface should not have 'CreateCheep' functionality