### PR TITLE
Fix database mishmatch by adding missing Migration

### DIFF
--- a/src/Repositories/Migrations/20231022020800_addNewContraints.Designer.cs
+++ b/src/Repositories/Migrations/20231022020800_addNewContraints.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Repositories;
 
@@ -10,9 +11,11 @@ using Repositories;
 namespace Repositories.Migrations
 {
     [DbContext(typeof(ChirpContext))]
-    partial class CheepContextModelSnapshot : ModelSnapshot
+    [Migration("20231022020800_addNewContraints")]
+    partial class addNewContraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.12");

--- a/src/Repositories/Migrations/20231022020800_addNewContraints.cs
+++ b/src/Repositories/Migrations/20231022020800_addNewContraints.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Repositories.Migrations
+{
+    /// <inheritdoc />
+    public partial class addNewContraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "AuthorId",
+                table: "Cheeps",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CheepId",
+                table: "Cheeps",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER")
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "AuthorId",
+                table: "Authors",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER")
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Authors_Email",
+                table: "Authors",
+                column: "Email",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Authors_Name",
+                table: "Authors",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Authors_Email",
+                table: "Authors");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Authors_Name",
+                table: "Authors");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AuthorId",
+                table: "Cheeps",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CheepId",
+                table: "Cheeps",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT")
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AuthorId",
+                table: "Authors",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT")
+                .Annotation("Sqlite:Autoincrement", true);
+        }
+    }
+}


### PR DESCRIPTION
There was missing a database migration file, from a previous database change. The project would work when created by the database.EnsureCreated() method, but not if created with the "dotnet ef database update" function. This migration fixes this.