### PR TITLE
Fix azure cant have static port set

### DIFF
--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -36,7 +36,6 @@ public class Program
         builder.Services.AddScoped<ICheepRepository, CheepRepository>();
         builder.Services.AddScoped<IAuthorRepository, AuthorRepository>();
         builder.Services.AddScoped<IReactionRepository, ReactionRepository>();
-        builder.WebHost.UseUrls("https://localhost:7022");
         
         // add user on signin if they do not exists
         builder.Services.Configure<OpenIdConnectOptions>(OpenIdConnectDefaults.AuthenticationScheme, options =>
@@ -56,7 +55,6 @@ public class Program
         });
 
         var app = builder.Build();
-
         // Configure the HTTP request pipeline.
         if (!app.Environment.IsDevelopment())
         {
@@ -73,6 +71,8 @@ public class Program
             app.UseExceptionHandler("/Error");
             // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
             app.UseHsts();
+        } else {
+            builder.WebHost.UseUrls("https://localhost:7022");
         }
 
         app.UseHttpsRedirection();


### PR DESCRIPTION
Azure needs to be able to set the port used with the ASPNETCORE_URLS environment variable. This wont work if we manually set the port with WebHost.UseUrls. To fix this we only specify what port to use in development mode.